### PR TITLE
Load README.md as utf-8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,10 @@ LICENSE = "Apache 2.0"
 DOWNLOAD_URL = "https://github.com/jgraving/deepposekit.git"
 VERSION = "0.3.4.dev"
 
+# read the contents of your README file
+this_directory = os.path.abspath(os.path.dirname(__file__))
+with open(os.path.join(this_directory, 'README.md'), encoding='utf-8') as f:
+    long_description = f.read()
 
 if __name__ == "__main__":
 
@@ -39,7 +43,7 @@ if __name__ == "__main__":
         maintainer=MAINTAINER,
         maintainer_email=MAINTAINER_EMAIL,
         description=DESCRIPTION,
-        long_description=open("README.md").read(),
+        long_description=long_description,
         long_description_content_type="text/markdown",
         license=LICENSE,
         url=URL,


### PR DESCRIPTION
I suspect that some conda users can currently not install your package because of unicode characters in the README.md:

* [More details in this stack overflow question](https://stackoverflow.com/questions/59274310/unicodedecodeerror-ascii-codec-cant-decode-byte-0xe2-in-position-433-ordina/59274661)

This pull request should fix this..