### PR TITLE
Base generator

### DIFF
--- a/deepposekit/io/BaseGenerator.py
+++ b/deepposekit/io/BaseGenerator.py
@@ -83,7 +83,7 @@ class BaseGenerator(Sequence):
         Takes a list or array of indexes corresponding to
         image-keypoint pairs in the dataset.
         Returns a numpy array of keypoints with the shape:
-        (1, n_keypoints, 2), where 2 is the x,y coordinates
+        (n_indexes, n_keypoints, 2), where 2 is the x,y coordinates
         """
         raise NotImplementedError()
 

--- a/deepposekit/io/BaseGenerator.py
+++ b/deepposekit/io/BaseGenerator.py
@@ -74,7 +74,7 @@ class BaseGenerator(Sequence):
         Takes a list or array of indexes corresponding
         to image-keypoint pairs in the dataset.
         Returns a numpy array of images with the shape:
-        (n_indexes, height, width, n_channels)
+        (n_samples, height, width, n_channels)
         """
         raise NotImplementedError()
 

--- a/deepposekit/io/BaseGenerator.py
+++ b/deepposekit/io/BaseGenerator.py
@@ -74,7 +74,7 @@ class BaseGenerator(Sequence):
         Takes a list or array of indexes corresponding
         to image-keypoint pairs in the dataset.
         Returns a numpy array of images with the shape:
-        (1, height, width, n_channels)
+        (n_indexes, height, width, n_channels)
         """
         raise NotImplementedError()
 

--- a/deepposekit/io/BaseGenerator.py
+++ b/deepposekit/io/BaseGenerator.py
@@ -83,7 +83,7 @@ class BaseGenerator(Sequence):
         Takes a list or array of indexes corresponding to
         image-keypoint pairs in the dataset.
         Returns a numpy array of keypoints with the shape:
-        (n_indexes, n_keypoints, 2), where 2 is the x,y coordinates
+        (n_samples, n_keypoints, 2), where 2 is the x,y coordinates
         """
         raise NotImplementedError()
 


### PR DESCRIPTION
Hi Jake!

I think I found two minor fixes for the documentation of two functions in BaseGenerator.py. In general you can pass multiple indexes to get_images() and get_keypoints(). Therefore documentations should say dimension is (n_indexes, ...) instead of (1, ...) I guess.

Best,
Urs