### PR TITLE
Fixing error metrics as discussed in #27

### DIFF
--- a/deepposekit/augment/FlipAxis.py
+++ b/deepposekit/augment/FlipAxis.py
@@ -23,7 +23,7 @@ from deepposekit.io.BaseGenerator import BaseGenerator
 __all__ = ["FlipAxis"]
 
 
-class FlipAxis(iaa.Flipud):
+class FlipAxis(iaa.Fliplr):
     """ Flips the input image and keypoints across an axis.
 
     A generalized class for flipping images and keypoints

--- a/deepposekit/augment/FlipAxis.py
+++ b/deepposekit/augment/FlipAxis.py
@@ -14,14 +14,16 @@
 # limitations under the License.
 
 import numpy as np
+import imgaug.augmenters as iaa
+import six.moves as sm
+import h5py
+
 from deepposekit.io.BaseGenerator import BaseGenerator
-from imgaug.augmenters import meta
-from imgaug import parameters as iap
 
 __all__ = ["FlipAxis"]
 
 
-class FlipAxis(meta.Augmenter):
+class FlipAxis(iaa.Flipud):
     """ Flips the input image and keypoints across an axis.
 
     A generalized class for flipping images and keypoints
@@ -37,82 +39,103 @@ class FlipAxis(meta.Augmenter):
         This can be a deepposekit.io.BaseGenerator for annotations
         or an array of integers specifying which keypoint indices
         to swap.
-        
-    p: int, default 0.5
-        The probability that an image is flipped
 
     axis: int, default 0
         Axis over which images are flipped
         axis=0 flips up-down (np.flipud)
         axis=1 flips left-right (np.fliplr)
-        
-    seed: None or int or np.random.RandomState, default None
-        The random state for the augmenter.
-        
+
     name: None or str, default None
         Name given to the Augmenter object. The name is used in print().
         If left as None, will print 'UnnamedX'
-        
+
     deterministic: bool, default False
         If set to true, each batch will be augmented the same way.
 
+    random_state: None or int or np.random.RandomState, default None
+        The random state for the augmenter.
 
     Attributes
     ----------
-    p: int
-        The probability that an image is flipped
-    
     axis: int
         The axis to reflect the image.
 
     swap_index: array
         The keypoint indices to swap when the image is flipped
-        
 
     """
 
-    def __init__(self, swap_index, p=0.5, axis=0, seed=None, name=None, deterministic=False):
-        super(FlipAxis, self).__init__(seed=seed, name=name, random_state="deprecated", deterministic=deterministic)
-        self.p = iap.handle_probability_param(p, "p")
+    def __init__(
+        self,
+        swap_index,
+        p=0.5,
+        axis=0,
+        name=None,
+        deterministic=False,
+        random_state=None,
+    ):
+
+        super(FlipAxis, self).__init__(
+            p=p, name=name, deterministic=deterministic, random_state=random_state
+        )
+
         self.axis = axis
         if isinstance(swap_index, BaseGenerator):
             if hasattr(swap_index, "swap_index"):
                 self.swap_index = swap_index.swap_index
         elif isinstance(swap_index, np.ndarray):
             self.swap_index = swap_index
-        
-    
-    def _augment_batch_(self, batch, random_state, parents, hooks):
-        samples = self.p.draw_samples((batch.nb_rows,),
-                                      random_state=random_state)
-        for i, sample in enumerate(samples):
-            if sample >= 0.5:
-                
-                if batch.images is not None:
-                    if self.axis == 0:
-                        batch.images[i] = np.flipud(batch.images[i])
+
+    def _augment_images(self, images, random_state, parents, hooks):
+        """ Augments the images
+
+        Handles the augmentation over a specified axis
+
+        Returns
+        -------
+        images: array
+            Array of augmented images.
+
+        """
+        nb_images = len(images)
+        samples = self.p.draw_samples((nb_images,), random_state=random_state)
+        for i in sm.xrange(nb_images):
+            if samples[i] == 1:
+                if self.axis == 1:
+                    images[i] = np.fliplr(images[i])
+                elif self.axis == 0:
+                    images[i] = np.flipud(images[i])
+        self.samples = samples
+        return images
+
+    def _augment_keypoints(self, keypoints_on_images, random_state, parents, hooks):
+        """ Augments the keypoints
+
+        Handles the augmentation over a specified axis
+        and swaps the keypoint labels using swap_index.
+        For example, the left leg will be swapped with the right leg
+        This is accomplished by reordering the keypoints.
+
+        Returns
+        -------
+        keypoints_on_images: array
+            Array of new coordinates of the keypoints.
+
+        """
+        nb_images = len(keypoints_on_images)
+        samples = self.p.draw_samples((nb_images,), random_state=random_state)
+        for i, keypoints_on_image in enumerate(keypoints_on_images):
+            if samples[i] == 1:
+                for keypoint in keypoints_on_image.keypoints:
                     if self.axis == 1:
-                        batch.images[i] = np.fliplr(batch.images[i])
-
-
-                if batch.keypoints is not None:
-                    kpsoi = batch.keypoints[i]
-                    if self.axis == 0:
-                        height = kpsoi.shape[0]
-                        for kp in kpsoi.keypoints:
-                            kp.y = (height-1) - kp.y
-                    if self.axis == 1:
-                        width = kpsoi.shape[1]
-                        for kp in kpsoi.keypoints:
-                            kp.x = (width-1) - kp.x
-                    swapped = kpsoi.keypoints.copy()
-                    for r in range(len(kpsoi.keypoints)):
-                        idx = self.swap_index[r]
-                        if idx >= 0:
-                            kpsoi.keypoints[r] = swapped[idx]
-
-        return batch
-
-    def get_parameters(self):
-        """See :func:`~imgaug.augmenters.meta.Augmenter.get_parameters`."""
-        return [self.p, self.axis, self.swap_index]
+                        width = keypoints_on_image.shape[1]
+                        keypoint.x = (width - 1) - keypoint.x
+                    elif self.axis == 0:
+                        height = keypoints_on_image.shape[0]
+                        keypoint.y = (height - 1) - keypoint.y
+                swapped = keypoints_on_image.keypoints.copy()
+                for r in range(len(keypoints_on_image.keypoints)):
+                    idx = self.swap_index[r]
+                    if idx >= 0:
+                        keypoints_on_image.keypoints[r] = swapped[idx]
+        return keypoints_on_images

--- a/deepposekit/callbacks.py
+++ b/deepposekit/callbacks.py
@@ -125,8 +125,8 @@ class Logger(Callback):
                 for key, value in values.items():
                     data = h5file["logs"][key]
                     value = np.array(value)
-                    data.resize(tuple(value.shape))
                     if data.shape[0] == 0:
+                        data.resize(tuple(value.shape))
                         data[:] = value
                     else:
                         data.resize(data.shape[0] + 1, axis=0)
@@ -150,15 +150,6 @@ class Logger(Callback):
         euclidean_mean = euclidean.mean()
         confidence_perc = np.percentile(confidence, [0, 5, 25, 50, 75, 95, 100])
         confidence_mean = confidence.mean()
-        # keypoint_percentile = np.percentile(
-        #     [euclidean, confidence], [0, 5, 25, 50, 75, 95, 100], axis=1
-        # ).T
-        # euclidean_perc, confidence_perc = keypoint_percentile
-
-        # euclidean_mean, confidence_mean = np.mean([euclidean, confidence], axis=1)
-
-        logs["euclidean"] = euclidean_mean
-        logs["confidence"] = confidence_mean
 
         if self.verbose:
             print(

--- a/deepposekit/callbacks.py
+++ b/deepposekit/callbacks.py
@@ -134,18 +134,28 @@ class Logger(Callback):
 
         euclidean = euclidean.flatten()
         confidence = confidence.flatten()
+        y_visible = ~np.isnan(y_error[...,0].flatten())
 
         if self.confidence_threshold:
             mask = confidence >= confidence_threshold
             euclidean = euclidean[mask]
             confidence = confidence[mask]
+            y_visible = y_visible[mask]
+            
+        if ~y_visible.all():
+            euclidean = euclidean[y_visible]
+            confidence[~y_visible] = 1-confidence[~y_visible]
 
-        keypoint_percentile = np.percentile(
-            [euclidean, confidence], [0, 5, 25, 50, 75, 95, 100], axis=1
-        ).T
-        euclidean_perc, confidence_perc = keypoint_percentile
+        euclidean_perc = np.percentile(euclidean, [0, 5, 25, 50, 75, 95, 100])
+        euclidean_mean = euclidean.mean()
+        confidence_perc = np.percentile(confidence, [0, 5, 25, 50, 75, 95, 100])
+        confidence_mean = confidence.mean()
+        # keypoint_percentile = np.percentile(
+        #     [euclidean, confidence], [0, 5, 25, 50, 75, 95, 100], axis=1
+        # ).T
+        # euclidean_perc, confidence_perc = keypoint_percentile
 
-        euclidean_mean, confidence_mean = np.mean([euclidean, confidence], axis=1)
+        # euclidean_mean, confidence_mean = np.mean([euclidean, confidence], axis=1)
 
         logs["euclidean"] = euclidean_mean
         logs["confidence"] = confidence_mean

--- a/deepposekit/callbacks.py
+++ b/deepposekit/callbacks.py
@@ -113,7 +113,7 @@ class Logger(Callback):
         euclidean = evaluation_dict["euclidean"]
         confidence = evaluation_dict["confidence"]
         if self.filepath is not None:
-            with h5py.File(self.filepath) as h5file:
+            with h5py.File(self.filepath, 'r+') as h5file:
                 values = {
                     "val_loss": np.array([logs.get("val_loss")]).reshape(1),
                     "loss": np.array([logs.get("loss")]).reshape(1),

--- a/deepposekit/utils/keypoints.py
+++ b/deepposekit/utils/keypoints.py
@@ -185,6 +185,7 @@ def imgaug_to_numpy(keypoints):
 
 
 def keypoint_errors(y_true, y_pred):
+    y_true[y_true<-100] = np.NaN # Non-visible points have keypoint location -99999 before augmentation
     y_error = y_true - y_pred
 
     euclidean = np.sqrt(np.sum(y_error ** 2, axis=-1))

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ if __name__ == "__main__":
             "h5py",
             "imgaug>=0.2.9",
             "opencv-python",
+            "pyyaml",
         ],
         packages=find_packages(),
         zip_safe=False,


### PR DESCRIPTION
I implemented these changes, plus two minor additions.

First, for keypoints which are supposed to be not-visible, it seemed reasonable to replace their confience score with 1 minus the confidence score, for the purposes of reporting online during training, since the target confidence for these points is 0. Euclidean errors however should be masked out, since they are not defined for non-visible keypoints. These changes only affect values printed to command line during training, but not logged values to disk. This is fine, because the keypoint errors logged to disk includes NaN values for non-visible keypoints

Second, in debugging these changes, I noticed that the logger callback appeared to be broken. Instead of adding a new entry for each epoch, it appears to have a first entry with all zeros, and a second entry with only the most recent values. This looked like a single line got misplaced outside a conditional statement, and I tested that logger works correctly after making this change.