### PR TITLE
Changes in Annotator.py and DataGenerator.py

### DIFF
--- a/deepposekit/annotate/gui/Annotator.py
+++ b/deepposekit/annotate/gui/Annotator.py
@@ -182,7 +182,8 @@ class Annotator(GUI):
                 )
 
             # Unpack the images from the file
-            self.image_idx = np.sum(np.all(h5file["annotated"].value, axis=1)) - 1
+            # self.image_idx = np.sum(np.all(h5file["annotated"].value, axis=1)) - 1
+            self.image_idx = np.sum(np.all(h5file["annotated"][()], axis=1)) - 1 # h5py version 3.x
 
             self.image = h5file[self.dataset][self.image_idx]
             self._check_grayscale()
@@ -196,7 +197,7 @@ class Annotator(GUI):
         using 'ctrl + s' keys.
 
         """
-        with h5py.File(self.datapath) as h5file:
+        with h5py.File(self.datapath, "r+") as h5file:
 
             h5file["annotations"][self.image_idx] = self.skeleton.loc[
                 :, ["x", "y"]

--- a/deepposekit/io/DataGenerator.py
+++ b/deepposekit/io/DataGenerator.py
@@ -78,7 +78,8 @@ class DataGenerator(BaseGenerator):
                 raise ValueError("mode must be 'full', 'annotated', or 'unannotated'")
             else:
                 self.mode = mode
-            self.annotated = np.all(h5file["annotated"].value, axis=1)
+            # self.annotated = np.all(h5file["annotated"].value, axis=1)
+            self.annotated = np.all(h5file["annotated"][()], axis=1) # h5py version 3.x
             self.annotated_index = np.where(self.annotated)[0]
             self.n_annotated = self.annotated_index.shape[0]
             if self.n_annotated == 0 and self.mode not in ["full", "unannotated"]:


### PR DESCRIPTION
1. Updated h5file["annotated"].value to h5py v3.x. Instead of `.value`, using [()] for indexing works both in h5py 3.x and lower versions.
2. It seems that an "r+" in the crucial with-open-as sentence in function `_save()` is ignored.